### PR TITLE
feat(profiles_links): add profiles links for older FR agents

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanFlameGraph.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanFlameGraph.tsx
@@ -97,8 +97,7 @@ export default function SpanFlameGraph(props: SpanFlameGraphProps) {
     async (
       profilesDataSourceSettings: DataSourceInstanceSettings<DataSourceJsonData>,
       traceToProfilesOptions: TraceToProfilesOptions,
-      span: TraceSpan,
-      isOldFusionReactorSpan: boolean
+      span: TraceSpan
     ) => {
       let labelSelector = '{}';
       if (traceToProfilesOptions.customQuery && traceToProfilesOptions.query) {
@@ -146,9 +145,16 @@ export default function SpanFlameGraph(props: SpanFlameGraphProps) {
       if (flameGraph && flameGraph.length > 0) {
         setTraceFlameGraphs({ ...traceFlameGraphs, [profileTagValue]: flameGraph });
       }
-    },
-    [getTimeRangeForProfile, profileTagValue, setTraceFlameGraphs, timeZone, traceDuration, traceFlameGraphs, traceName]
-  );
+    }, [
+      getTimeRangeForProfile,
+      profileTagValue,
+      setTraceFlameGraphs, 
+      timeZone, 
+      traceDuration, 
+      traceFlameGraphs,
+      traceName, 
+      isOldFusionReactorSpan
+  ]);
 
   useEffect(() => {
     if (!Object.keys(traceFlameGraphs).includes(profileTagValue)) {
@@ -157,7 +163,7 @@ export default function SpanFlameGraph(props: SpanFlameGraphProps) {
         profilesDataSourceSettings = getDatasourceSrv().getInstanceSettings(traceToProfilesOptions.datasourceUid);
       }
       if (traceToProfilesOptions && profilesDataSourceSettings) {
-        queryFlameGraph(profilesDataSourceSettings, traceToProfilesOptions, span, isOldFusionReactorSpan);
+        queryFlameGraph(profilesDataSourceSettings, traceToProfilesOptions, span);
       }
     }
   }, [

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -32,7 +32,11 @@ import { TimeZone } from '@grafana/schema';
 import { DataLinkButton, Divider, Icon, TextArea, useStyles2 } from '@grafana/ui';
 import { RelatedProfilesTitle } from '@grafana-plugins/tempo/resultTransformer';
 
-import { pyroscopeProfileIdTagKey } from '../../../createSpanLink';
+import {
+  pyroscopeProfileIdTagKey, 
+  fusionReactorProfileIdTagKey, 
+  fusionReactorInstrumentationLibraryName
+} from '../../../createSpanLink';
 import { autoColor } from '../../Theme';
 import LabeledList from '../../common/LabeledList';
 import { KIND, LIBRARY_NAME, LIBRARY_VERSION, STATUS, STATUS_MESSAGE, TRACE_STATE } from '../../constants/span';
@@ -434,18 +438,41 @@ export default function SpanDetail(props: SpanDetailProps) {
             createFocusSpanLink={createFocusSpanLink}
           />
         )}
-        {span.tags.some((tag) => tag.key === pyroscopeProfileIdTagKey) && (
-          <SpanFlameGraph
-            span={span}
-            timeZone={timeZone}
-            traceFlameGraphs={traceFlameGraphs}
-            setTraceFlameGraphs={setTraceFlameGraphs}
-            traceToProfilesOptions={traceToProfilesOptions}
-            setRedrawListView={setRedrawListView}
-            traceDuration={traceDuration}
-            traceName={traceName}
-          />
-        )}
+        {(() => {
+          if (span.tags.some((tag) => tag.key === pyroscopeProfileIdTagKey)) {
+            return (
+              <SpanFlameGraph
+                span={span}
+                timeZone={timeZone}
+                traceFlameGraphs={traceFlameGraphs}
+                setTraceFlameGraphs={setTraceFlameGraphs}
+                traceToProfilesOptions={traceToProfilesOptions}
+                setRedrawListView={setRedrawListView}
+                traceDuration={traceDuration}
+                traceName={traceName}
+                isOldFusionReactorSpan={false}
+              />
+            );
+          } else if (
+            span.instrumentationLibraryName === fusionReactorInstrumentationLibraryName &&
+            span.tags.some((tag) => tag.key === fusionReactorProfileIdTagKey)
+          ) {
+            return (
+              <SpanFlameGraph
+                span={span}
+                timeZone={timeZone}
+                traceFlameGraphs={traceFlameGraphs}
+                setTraceFlameGraphs={setTraceFlameGraphs}
+                traceToProfilesOptions={traceToProfilesOptions}
+                setRedrawListView={setRedrawListView}
+                traceDuration={traceDuration}
+                traceName={traceName}
+                isOldFusionReactorSpan={true}
+              />
+            );
+          }
+          return null;
+        })()}
         <small className={styles.debugInfo}>
           {/* TODO: fix keyboard a11y */}
           {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}


### PR DESCRIPTION
Issue:
Traces to profiles links currently aren't supported for or older versions of the FusionReactor agent. The exported profiles don't contain the info/ID of the linked span and the exported spans don't contain the `pyroscope.profile.id` attribute/tag which Grafana uses to identify a traces-to-profiles link.

Solution:
- The spans have a `pid` attribute to identify a linked profile instead, Grafana could use this to create a link to the profile.
- The span selector needs to be removed due to the profiles missing the span info.
- The Tempo datasource needs to be configured to use `txnId` as a tag, in place of `pyroscope.profile.id`, within the trace to profiles section for the query to find the associated profile.

`createSpanLink.tsx` and `links.ts` changed to handle adding the profiles link button. Changed query seems to be defined in Tempo's [resultTransformer.ts](https://github.com/intergral/grafana/blob/main/public/app/plugins/datasource/tempo/resultTransformer.ts#L437).

`index.tsx` and `SpanFlameGraph.tsx` changed to handle adding the flame graph to span.

