### PR TITLE
feat(alerting): put FusionReactor logo & information on alert emails

### DIFF
--- a/public/emails/ng_alert_notification.html
+++ b/public/emails/ng_alert_notification.html
@@ -160,7 +160,7 @@
                           <tbody>
                             <tr>
                               <td style="width:200px;">
-                                <img height="auto" src="https://app.fusionreactor.io/assets/FRLogo-blue-black.svg"
+                                <img height="auto" src="https://app.fusionreactor.io/assets/fr-logo-blue-black.png"
                                      style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
                                      width="200">
                               </td>

--- a/public/emails/ng_alert_notification.html
+++ b/public/emails/ng_alert_notification.html
@@ -151,7 +151,8 @@
             <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
               {{ __dangerouslyInjectHTML `<!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->` }}
               <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="background-color:#262c38;vertical-align:top;" width="100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;"
+                       width="100%">
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:15px 20px;word-break:break-word;">
@@ -159,7 +160,9 @@
                           <tbody>
                             <tr>
                               <td style="width:200px;">
-                                <img height="auto" src="https://app.fusionreactor.io/assets/FRLogo-blue-white.svg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="200">
+                                <img height="auto" src="https://app.fusionreactor.io/assets/FRLogo-blue-black.svg"
+                                     style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
+                                     width="200">
                               </td>
                             </tr>
                           </tbody>
@@ -1256,11 +1259,20 @@
             <td style="direction:ltr;font-size:0px;padding:20px 0;padding-top:10px;text-align:center;">
               {{ __dangerouslyInjectHTML `<!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->` }}
               <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="background-color:#262c38;vertical-align:top;" width="100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
                       <td align="center" class="txt" style="font-size:0px;padding:15px 25px;word-break:break-word;">
-                        <div style="font-family: Inter, Helvetica, Arial; font-size: 13px; line-height: 150%; text-align: center; color: #ffffff;">&copy; {{ now | date "2006" }} Grafana Labs. All rights reserved.<br>Sent by <a href="https://app.fusionreactor.io" style="color: #6E9FFF;">FusionReactor Cloud</a><br><br>Intergral Information Solutions GmbH, Im Hoelderle 3, 72224 Ebhausen, Germany<br>Contact: <a href="mailto:sales@fusion-reactor.com" style="color: #6E9FFF;">sales@fusion-reactor.com</a><br>Company Registration: Amtsgericht Stuttgart, HRB 4591<br>Directors: David Tattersall, Darren Pywell</div>
+                        <div style="font-family: Inter, Helvetica, Arial; font-size: 13px; line-height: 150%; text-align: center;">
+                          Sent by <a href="https://app.fusionreactor.io" style="color: #6E9FFF;">FusionReactor Cloud</a>
+                          <br><br>
+                          <span style="font-size: 9px;">
+                            Intergral Information Solutions GmbH, Im Hoelderle 3, 72224 Ebhausen, Germany
+                            <br>Contact: <a href="mailto:sales@fusion-reactor.com" style="color: #6E9FFF;">sales@fusion-reactor.com</a>
+                            <br>Company Registration: Amtsgericht Stuttgart, HRB 4591
+                            <br>Directors: David Tattersall, Darren Pywell
+                          </span>
+                        </div>
                       </td>
                     </tr>
                   </tbody>

--- a/public/emails/ng_alert_notification.html
+++ b/public/emails/ng_alert_notification.html
@@ -1268,7 +1268,7 @@
                           <br><br>
                           <span style="font-size: 9px;">
                             Intergral Information Solutions GmbH, Im Hoelderle 3, 72224 Ebhausen, Germany
-                            <br>Contact: <a href="mailto:sales@fusion-reactor.com" style="color: #6E9FFF;">sales@fusion-reactor.com</a>
+                            <br>Contact: <a href="mailto:support@fusion-reactor.com" style="color: #6E9FFF;">support@fusion-reactor.com</a>
                             <br>Company Registration: Amtsgericht Stuttgart, HRB 4591
                             <br>Directors: David Tattersall, Darren Pywell
                           </span>

--- a/public/emails/ng_alert_notification.html
+++ b/public/emails/ng_alert_notification.html
@@ -151,15 +151,15 @@
             <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
               {{ __dangerouslyInjectHTML `<!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->` }}
               <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="background-color:transparent;vertical-align:top;" width="100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="background-color:#262c38;vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:15px 20px;word-break:break-word;">
                         <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
                           <tbody>
                             <tr>
                               <td style="width:200px;">
-                                <img height="auto" src="https://grafana.com/static/assets/img/logo_new_transparent_light_400x100.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="200">
+                                <img height="auto" src="https://app.fusionreactor.io/assets/FRLogo-blue-white.svg" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="200">
                               </td>
                             </tr>
                           </tbody>
@@ -279,7 +279,7 @@
                     <tr>
                       <td align="left" class="txt" style="font-size:0px;padding:0;word-break:break-word;">
                         <div style="font-family: Inter, Helvetica, Arial; font-size: 13px; line-height: 150%; text-align: left; color: #000000;">
-                          <h3>🔥 {{ .Alerts.Firing | len }} firing instances</h3>
+                          <h3>🚨 {{ .Alerts.Firing | len }} firing instances</h3>
                         </div>
                       </td>
                     </tr>
@@ -1256,11 +1256,11 @@
             <td style="direction:ltr;font-size:0px;padding:20px 0;padding-top:10px;text-align:center;">
               {{ __dangerouslyInjectHTML `<!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->` }}
               <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="background-color:transparent;vertical-align:top;" width="100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="background-color:#262c38;vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" class="txt" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family: Inter, Helvetica, Arial; font-size: 13px; line-height: 150%; text-align: center; color: #000000;">&copy; {{ now | date "2006" }} Grafana Labs. Sent by <a href="{{ .AppUrl }}" style="color: #6E9FFF;">Grafana v{{ .BuildVersion }}</a>.</div>
+                      <td align="center" class="txt" style="font-size:0px;padding:15px 25px;word-break:break-word;">
+                        <div style="font-family: Inter, Helvetica, Arial; font-size: 13px; line-height: 150%; text-align: center; color: #ffffff;">&copy; {{ now | date "2006" }} Grafana Labs. All rights reserved.<br>Sent by <a href="https://app.fusionreactor.io" style="color: #6E9FFF;">FusionReactor Cloud</a><br><br>Intergral Information Solutions GmbH, Im Hoelderle 3, 72224 Ebhausen, Germany<br>Contact: <a href="mailto:sales@fusion-reactor.com" style="color: #6E9FFF;">sales@fusion-reactor.com</a><br>Company Registration: Amtsgericht Stuttgart, HRB 4591<br>Directors: David Tattersall, Darren Pywell</div>
                       </td>
                     </tr>
                   </tbody>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This update puts the FusionReactor logo and contact details onto all email alerts sent out by grafana

**Why do we need this feature?**

To replace the current template which has Grafana's logo and information instead.

**Who is this feature for?**

Customers with email based contact points

**Which issue(s) does this PR fix?**:

FRUI-249

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
