### PR TITLE
fix(intergral/docker): remove existing plugin dir before extraction on restart

### DIFF
--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -87,6 +87,10 @@ if [ -d "/custom-plugins" ]; then
   for zipfile in /custom-plugins/*.zip; do
     if [ -f "$zipfile" ]; then
       plugin_name=$(basename "$zipfile" .zip)
+      if [ -d "$GF_PATHS_PLUGINS/$plugin_name" ]; then
+        echo "Removing existing installation of plugin $plugin_name"
+        rm -rf "$GF_PATHS_PLUGINS/$plugin_name"
+      fi
       echo "Extracting custom plugin: $plugin_name"
       unzip -q "$zipfile" -d "$GF_PATHS_PLUGINS/$plugin_name"
     fi


### PR DESCRIPTION
## Summary
- Clean up existing plugin directory before unzip to prevent "write failed" errors on container restart
- Matches upstream Grafana plugin installation pattern (`pkg/plugins/storage/fs.go`)
- Logs removal for visibility during container startup