### PR TITLE
Revert the addition of the unpack code for docker startup.

### DIFF
--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -87,10 +87,6 @@ if [ -d "/custom-plugins" ]; then
   for zipfile in /custom-plugins/*.zip; do
     if [ -f "$zipfile" ]; then
       plugin_name=$(basename "$zipfile" .zip)
-      if [ -d "$GF_PATHS_PLUGINS/$plugin_name" ]; then
-        echo "Removing existing installation of plugin $plugin_name"
-        rm -rf "$GF_PATHS_PLUGINS/$plugin_name"
-      fi
       echo "Extracting custom plugin: $plugin_name"
       unzip -q "$zipfile" -d "$GF_PATHS_PLUGINS/$plugin_name"
     fi

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -80,20 +80,6 @@ if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then
   fi
 fi
 
-# ============================================================================
-# INTERGRAL CUSTOMIZATION: Extract custom plugins from zip files
-# ============================================================================
-if [ -d "/custom-plugins" ]; then
-  for zipfile in /custom-plugins/*.zip; do
-    if [ -f "$zipfile" ]; then
-      plugin_name=$(basename "$zipfile" .zip)
-      echo "Extracting custom plugin: $plugin_name"
-      unzip -q "$zipfile" -d "$GF_PATHS_PLUGINS/$plugin_name"
-    fi
-  done
-fi
-# ============================================================================
-
 exec grafana server                                         \
   --homepath="$GF_PATHS_HOME"                               \
   --config="$GF_PATHS_CONFIG"                               \


### PR DESCRIPTION
Not required any more because (hopefully) a change to the container deployment (in services) will get these plugins unpacked automatically for us.