### PR TITLE
feat(intergral/alerting): FusionReactor branding in alert emails

### DIFF
--- a/public/emails/ng_alert_notification.html
+++ b/public/emails/ng_alert_notification.html
@@ -146,15 +146,15 @@
             <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
               {{ __dangerouslyInjectHTML `<!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->` }}
               <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="background-color:transparent;vertical-align:top;" width="100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                      <td align="left" style="font-size:0px;padding:15px 20px;word-break:break-word;">
                         <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
                           <tbody>
                             <tr>
                               <td style="width:200px;">
-                                <img alt src="https://grafana.com/static/assets/img/logo_new_transparent_light_400x100.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="200" height="auto">
+                                <img alt src="https://app.fusionreactor.io/assets/fr-logo-blue-black.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="200" height="auto">
                               </td>
                             </tr>
                           </tbody>
@@ -273,7 +273,7 @@
                     <tr>
                       <td align="left" class="txt" style="font-size:0px;padding:0;word-break:break-word;">
                         <div style="font-family: Inter, Helvetica, Arial; font-size: 13px; line-height: 150%; text-align: left; color: #000000;">
-                          <h3>🔥 {{ .Alerts.Firing | len }} firing instances</h3>
+                          <h3>🚨 {{ .Alerts.Firing | len }} firing instances</h3>
                         </div>
                       </td>
                     </tr>
@@ -1246,11 +1246,20 @@
             <td style="direction:ltr;font-size:0px;padding:20px 0;padding-top:10px;text-align:center;">
               {{ __dangerouslyInjectHTML `<!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->` }}
               <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="background-color:transparent;vertical-align:top;" width="100%">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                   <tbody>
                     <tr>
-                      <td align="center" class="txt" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family: Inter, Helvetica, Arial; font-size: 13px; line-height: 150%; text-align: center; color: #000000;">&copy; {{ now | date "2006" }} Grafana Labs. Sent by <a href="{{ .AppUrl }}" style="color: #6E9FFF;">Grafana v{{ .BuildVersion }}</a>.</div>
+                      <td align="center" class="txt" style="font-size:0px;padding:15px 25px;word-break:break-word;">
+                        <div style="font-family: Inter, Helvetica, Arial; font-size: 13px; line-height: 150%; text-align: center;">
+                          Sent by <a href="https://app.fusionreactor.io" style="color: #6E9FFF;">FusionReactor Cloud</a>
+                          <br><br>
+                          <span style="font-size: 9px;">
+                            Intergral Information Solutions GmbH, Im Hoelderle 3, 72224 Ebhausen, Germany
+                            <br>Contact: <a href="mailto:support@fusion-reactor.com" style="color: #6E9FFF;">support@fusion-reactor.com</a>
+                            <br>Company Registration: Amtsgericht Stuttgart, HRB 4591
+                            <br>Directors: David Tattersall, Darren Pywell
+                          </span>
+                        </div>
                       </td>
                     </tr>
                   </tbody>


### PR DESCRIPTION
## Summary
- Forward-port of PR #51 from v12.0.x to 12.3.x-intergral
- Replaces Grafana logo with FusionReactor logo in alert email header
- Changes firing instances emoji from fire to siren
- Replaces Grafana Labs footer with FusionReactor Cloud / Intergral company info